### PR TITLE
Include secondary on-call rotation in schedule

### DIFF
--- a/duo_oncall.12h.py
+++ b/duo_oncall.12h.py
@@ -23,7 +23,7 @@ CREDS_FILE = ".victorops"
 CONFIG_FILE = ".config.ini"
 DT_FMT = "%Y-%m-%dT%H:%M:%S%z"
 FMT = " | color=#000001,#FFFFFE md=True"
-SCHEDULE_URI = "/v2/team/{team}/oncall/schedule?daysForward=30"
+SCHEDULE_URI = "/v2/team/{team}/oncall/schedule?daysForward=30&step=1"
 SWIFTBAR_CACHE_PATH = os.environ.get(
     "SWIFTBAR_PLUGIN_CACHE_PATH",
     CACHE_PATH
@@ -277,6 +277,7 @@ def main():
         display_conf = conf["display_conf"]
     except KeyError:
         display_conf = {}
+
     print("DuoOnCall")
     sep()
     creds = _get_creds()


### PR DESCRIPTION
## Summary
- Adds `&step=1` to the VictorOps schedule API request to include the secondary escalation step
- This surfaces the `DDASSecondary` and `DirectorySecondary` shifts alongside the existing primary rotation
- No display logic changes needed — the existing code already handles multiple shifts per day

## Test plan
- [x] Verified the API returns secondary rotation data with `step=1`
- [x] Confirmed N/A entries (static escalation users with no rolls) are harmlessly skipped
- [x] Confirmed date range grouping still works correctly with additional shifts
- [x] Verify output looks correct in SwiftBar menu bar dropdown

<img width="464" height="791" alt="Screenshot 2026-03-03 at 2 53 59 PM" src="https://github.com/user-attachments/assets/2b6ddc0e-9b45-496e-92ec-4df635c7ed79" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)